### PR TITLE
Fixes a couple of problems I ran into

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -56,7 +56,7 @@ export const apiGatewayResponse = async (response?: ServerResponse) => {
     return { statusCode: 500 };
   }
   if (!response.body) {
-    return response;
+    return { statusCode: response.status };
   }
   let arrayBuf;
   if (isReader(response.body)) {

--- a/mod.ts
+++ b/mod.ts
@@ -69,7 +69,7 @@ export const apiGatewayResponse = async (response?: ServerResponse) => {
   const rawHeaders: { [key: string]: string } = {};
   response.headers.forEach((v, k) => (rawHeaders[k] = v));
   return {
-    ...response,
+    statusCode: response.status,
     body: new TextDecoder().decode(arrayBuf).trim(),
     headers: rawHeaders,
   };

--- a/mod.ts
+++ b/mod.ts
@@ -30,7 +30,7 @@ export const serverRequest = (
   event: APIGatewayProxyEvent,
   context: Context
 ): ServerRequest => {
-  const headers = new Headers(event.headers);
+  const headers = new Headers(event.headers ?? undefined);
   const url = eventUrl(event);
   const body = <Deno.Reader>new StringReader(event.body ?? "");
 


### PR DESCRIPTION
1. When there are no headers in the request, the events.header field is set to null. Unfortunately, the Headers(init) constructor fails when it's passed a null parameter. This uses the Headers() constructor instead in that case.

2. The Lambda response is expected to have a statusCode field with the appropriate http status code. The code was setting a status field instead. Since there was no statusCode field, every response was interpreted as a 500 server error.